### PR TITLE
Fixed failing documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,7 @@ if(BUILD_STATIC_ANALYSIS)
     FILE(GLOB_RECURSE CPP_HEADERS LIST_DIRECTORIES false ${CPP_DIR}/KML/include/*.h ${CPP_DIR} ${CPP_DIR}/KML/include/*.tcc)
     SET(CPP_ALL ${CPP_SOURCES} ${CPP_HEADERS})
     HEADER_DIRECTORIES(HEADERS ${CPP_DIR}/KML/include)
+    message("${HEADERS}")
 
     # CLANG-TIDY
     FIND_PROGRAM(CLANG_TIDY "clang-tidy")
@@ -266,7 +267,7 @@ if(BUILD_STATIC_ANALYSIS)
                 -x c++
                 -std=c++${CMAKE_CXX_STANDARD}
                 ${TIDY_INCLUDE_DIRS}
-            COMMENT "   Clang-Tidy"
+            COMMENT "Clang-Tidy"
         )
 	endif()
 
@@ -293,7 +294,7 @@ if(BUILD_STATIC_ANALYSIS)
             )
             ADD_CUSTOM_TARGET(ANALYZE_CPPCHECK ALL DEPENDS ${BINARY}
                 COMMAND ${CMAKE_CXX_CPPCHECK}
-                COMMENT "   CPPCHECK"
+                COMMENT "CPPCHECK"
             )
         endif()
     endif()

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,18 @@ compile-all: directories
 	    -DBUILD_TESTING=ON \
 		-DBUILD_PYTHON=ON \
 		-DBUILD_COVERAGE=ON \
+		-DBUILD_DOCUMENTATION=ON \
+		-DBUILD_STATIC_ANALYSIS=ON && \
+	make -j
+
+analyze: directories
+	cd $(BUILDDIR) && \
+	cmake \
+	    .. \
+	    -DCMAKE_BUILD_TYPE=Debug \
+	    -DBUILD_TESTING=OFF \
+		-DBUILD_PYTHON=OFF \
+		-DBUILD_COVERAGE=OFF \
 		-DBUILD_DOCUMENTATION=OFF \
 		-DBUILD_STATIC_ANALYSIS=ON && \
 	make -j
@@ -81,7 +93,7 @@ test_wheel:
 	cd $(BUILDDIR)/tools/packages && \
 	python3 -m pip install KML*.whl --force-reinstall && \
 	python3 -m pytest -p no:cacheprovider ../python/tests && \
-	pip uninstall KML
+	pip uninstall KML -y
 
 ## Call Unittests for C++/Python for sdist. Requires prior build.
 test_source:
@@ -89,7 +101,7 @@ test_source:
 	cd $(BUILDDIR)/tools/packages && \
 	pip3 install KML*.tar.gz --force-reinstall && \
 	python3 -m pytest -p no:cacheprovider ../python/tests && \
-	pip uninstall KML
+	pip uninstall KML -y
 
 ## Test Docker image
 docker_test: build

--- a/cmake/FindSphinx.cmake
+++ b/cmake/FindSphinx.cmake
@@ -1,0 +1,12 @@
+# Look for an executable called sphinx-build
+FIND_PROGRAM(SPHINX_EXECUTABLE
+             NAMES sphinx-build
+             DOC "Path to sphinx-build executable")
+
+INCLUDE(FindPackageHandleStandardArgs)
+
+# Handle standard arguments to find_package like REQUIRED and QUIET
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(
+    Sphinx
+    "Failed to find sphinx-build executable"
+    SPHINX_EXECUTABLE)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -66,7 +66,7 @@ exhale_args = {
     "containmentFolder": "_build/cpp_api",
     "rootFileName": "library_root.rst",
     "rootFileTitle": "C++ API",
-    "doxygenStripFromPath": f"{PROJECT_DIR}/tools/cpp",
+    "doxygenStripFromPath": f"{PROJECT_DIR}/tools/cpp/",
     ############################################################################
     # Suggested optional arguments.                                            #
     ############################################################################
@@ -77,15 +77,6 @@ exhale_args = {
     "exhaleDoxygenStdin": dedent(
         """
      INPUT       = ../../tools/cpp/KML/
-     FULL_PATH_NAMES        = NO
-     XML_PROGRAMLISTING     = YES
-     CREATE_SUBDIRS         = NO
-     AUTOLINK_SUPPORT       = NO
-     INLINE_INHERITED_MEMB  = YES
-     ENABLE_PREPROCESSING   = YES
-     MACRO_EXPANSION        = YES
-     EXPAND_ONLY_PREDEF     = NO
-     SKIP_FUNCTION_MACROS   = NO
      FILE_PATTERNS          = *.h *.tcc *.cc
     """
     ),
@@ -109,18 +100,17 @@ exhale_args = {
         """
     """
     ),
-    # "fullApiSubSectionTitle": "Full API",
-    # "afterBodySummary": dedent(
-    #    """
-    # """
-    # ),
-    #############################################################################
-    ## Individual page layout example configuration.                            #
-    #############################################################################
+    "fullApiSubSectionTitle": "Full API",
+    "afterBodySummary": dedent(
+        """
+     """
+    ),
+    ############################################################################
+    # Individual page layout example configuration.                            #
+    ############################################################################
     # Example of adding contents directives on custom kinds with custom title
-    # "contentsTitle": "Page Contents",
-    # "kindsWithContentsDirectives": ["class", "file", "namespace", "struct"],
-    # "includeTemplateParamOrderList": False,
+    "contentsTitle": "Page Contents",
+    "kindsWithContentsDirectives": ["dir", "class", "file", "namespace", "struct"],
     #############################################################################
     # useful to see ;)
     "verboseBuild": True,
@@ -160,7 +150,7 @@ html_sidebars = {"**": ["logo-text.html", "globaltoc.html", "searchbox.html"]}
 html_context = {
     # "display_github": True,  # Add 'Edit on Github' link instead of 'View page source'
     # "last_updated": True,
-    "commit": False,
+    "commit": False
 }
 
 pygments_style = "sphinx"

--- a/docs/source/pages/python_guidelines.rst
+++ b/docs/source/pages/python_guidelines.rst
@@ -3,7 +3,7 @@
    :align: right
    :target: https://github.com/shkevin/KML
 
-.. _cpp_guidelines:
+.. _python_guidelines:
 
 ========================
 Cython/Python Guidelines

--- a/tools/cpp/KML/include/data_structures/LinkedList.h
+++ b/tools/cpp/KML/include/data_structures/LinkedList.h
@@ -1,6 +1,6 @@
 /*!
- * @file DoublyLinkedList.h
- * @brief Provides the declarations for the Doubly Linked List data structure.
+ * @file  LinkedList.h
+ * @brief Provides the declarations for the Linked List data structure.
  */
 #ifndef __LINKED_LIST_H__
 #define __LINKED_LIST_H__
@@ -14,7 +14,9 @@ namespace KML
 {
     namespace DataStructures
     {
-
+        /*!
+         * @brief Windowed LinkedList class.
+         */
         template<typename T = double>
         class LinkedList : public IDataStructure<T>
         {
@@ -41,9 +43,19 @@ namespace KML
                 LinkedList &operator=(const LinkedList &) = delete;  // No copy
 
                 /*!
+                 * @brief Move Constructor.
+                 */
+                LinkedList(LinkedList<T>&& other);
+    
+                /*!
+                 * @brief Move Assignment.
+                 */
+                LinkedList<T>& operator=(LinkedList<T>&& rhs);
+
+                /*!
 				 * @copydoc IDataStructure::update()
 				 */
-                virtual void update(const T &item) override;
+                void update(const T &item) override;
 
                 /*!
 				 * @copydoc IDataStructure::update()
@@ -58,22 +70,22 @@ namespace KML
                 /*!
 				 * @copydoc IDataStructure::full()
 				 */
-                virtual bool full() const override;
+                bool full() const override;
 
                 /*!
 				 * @copydoc IDataStructure::empty()
 				 */
-                virtual bool empty() const override;
+                bool empty() const override;
 
                 /*!
 				 * @copydoc IDataStructure::size()
 				 */
-                virtual size_t size() const override;
+                size_t size() const override;
 
                 /*!
 				 * @copydoc IDataStructure::reset()
 				 */
-                virtual void reset() override;
+                void reset() override;
 
                 /*!
 				 * @brief Print out the node values to standard out.

--- a/tools/cpp/KML/include/data_structures/Node.h
+++ b/tools/cpp/KML/include/data_structures/Node.h
@@ -11,6 +11,9 @@ namespace KML
 {
     namespace DataStructures
     {
+        /*!
+         * @brief Node delcaration for LinkedLists.
+         */
         template<typename T = double>
         class Node
         {

--- a/tools/cpp/KML/include/data_structures/RingBuffer.h
+++ b/tools/cpp/KML/include/data_structures/RingBuffer.h
@@ -17,6 +17,9 @@ namespace KML
 {
     namespace DataStructures
     {
+        /*!
+         * @brief Streaming RingBuffer class declaration.
+         */
         template<typename T = double>
         class RingBuffer : public IDataStructure<T>
         {

--- a/tools/cpp/KML/include/data_structures/histograms/IBin.h
+++ b/tools/cpp/KML/include/data_structures/histograms/IBin.h
@@ -1,5 +1,5 @@
 /*!
- * @file  Bin.h
+ * @file  IBin.h
  * @brief Provides an interface for bins used in Histograms.
  */
 #ifndef __HISTOGRAM_H__
@@ -55,7 +55,7 @@ namespace KML
                 /*!
                  * @brief Addition Operator.
                  */
-                IBin<T> operator+(const IBin<T>& other) const;
+                IBin<T> operator+(const IBin<T>& rhs) const;
 
                 /*!
                  * @brief Addition Assignmnet Operator.
@@ -76,8 +76,7 @@ namespace KML
                  * @brief Print Operator.
                  */
                 template<typename F>
-                friend std::ostream& operator<<(std::ostream& os,
-                                                const IBin<F>& bin);
+                friend std::ostream& operator<<(std::ostream& os, const IBin<F>& bin);
 
                 /*!
                  * @brief Get the bin count.

--- a/tools/cpp/KML/include/data_structures/histograms/IBin.tcc
+++ b/tools/cpp/KML/include/data_structures/histograms/IBin.tcc
@@ -7,8 +7,7 @@ namespace KML
     namespace DataStructures
     {
         template<typename T>
-        IBin<T>::IBin(T left, T right, size_t count)
-            : m_left(left), m_right(right), m_count(count)
+        IBin<T>::IBin(T left, T right, size_t count) : m_left(left), m_right(right), m_count(count)
         {
             // Do nothing.
         }
@@ -62,7 +61,7 @@ namespace KML
         }
 
         template<typename T>
-        IBin<T> IBin<T>::operator+(const IBin& rhs) const
+        IBin<T> IBin<T>::operator+(const IBin<T>& rhs) const
         {
             IBin l_bin = *this;
             if (rhs.m_left < l_bin.m_left) l_bin.m_left = rhs.m_left;
@@ -94,8 +93,7 @@ namespace KML
         template<typename T>
         std::ostream& operator<<(std::ostream& os, const IBin<T>& bin)
         {
-            os << "[" << bin.m_left << ", " << bin.m_right << "] -> "
-               << bin.m_count;
+            os << "[" << bin.m_left << ", " << bin.m_right << "] -> " << bin.m_count;
             return os;
         }
 

--- a/tools/cpp/KML/include/data_structures/histograms/IStreamingHistogram.h
+++ b/tools/cpp/KML/include/data_structures/histograms/IStreamingHistogram.h
@@ -29,12 +29,13 @@ namespace KML
         {
             public:
                 /*!
-                 * Default Constructor.
-                 * @param  numBins Number of bins the Histogram should maintain.
+                 * @brief Default Constructor.
+                 * @param numBins Number of bins the Histogram should maintain.
+                 * @param windowSize Desired window size of Histogram. This helps with data drift.
+                 * @param decay How to decay the counts.
                  */
-                explicit IStreamingHistogram(
-                    const size_t& numBins, const size_t& windowSize = 100,
-                    const DecayType decay = DecayType::WINDOW);
+                explicit IStreamingHistogram(const size_t& numBins, const size_t& windowSize = 100,
+                                             const DecayType& decay = DecayType::WINDOW);
 
                 /*!
                  * @copydoc IDataStructure::update()
@@ -44,28 +45,28 @@ namespace KML
                 /*!
                  * @brief Determine if the Linked List is full.
                  */
-                virtual bool full() const override;
+                bool full() const override;
 
                 /*!
                  * @brief Determine if the Linked List is empty.
                  */
-                virtual bool empty() const override;
+                bool empty() const override;
 
                 /*!
                  * @brief Retrieve the current number of nodes in the list.
                  */
-                virtual size_t size() const override;
+                size_t size() const override;
 
                 /*!
                  * @brief Completely reset the linked list.
                  */
-                virtual void reset() override;
+                void reset() override;
 
                 /*!
                  * @brief Get the index where the given bin should be inserted.
                  * @param bin The bin to find where to place in histogram.
                  */
-                size_t binSearch(const IBin<T> bin) const;
+                size_t binSearch(const IBin<T>& bin) const;
 
                 /*!
                  * @brief Calculate the approximate pdf from the histogram.
@@ -85,7 +86,7 @@ namespace KML
                  * @brief Get the bin edge corresponding to the pth percentile.
                  * @param qtile Which quantile to estimate.
                  */
-                T quantile(const double qtile) const;
+                T quantile(const double& qtile) const;
 
                 /*!
                  * @brief Retrieve the counts for each bin.
@@ -96,10 +97,9 @@ namespace KML
                  * @brief Print Operator.
                  */
                 template<typename F>
-                friend std::ostream& operator<<(
-                    std::ostream& os, const IStreamingHistogram<F>& hist);
+                friend std::ostream& operator<<(std::ostream& os,
+                                                const IStreamingHistogram<F>& hist);
 
-            protected:
                 /*!
                  * @brief Update the value used in normalizing the counts.
                  */
@@ -109,11 +109,6 @@ namespace KML
                  * @brief Decrease the count of an item outside of window.
                  */
                 void decayCounts();
-
-                /*!
-                 * @brief The value to normalize the counts in the histogram.
-                 */
-                double m_normalizer = 0.0;
 
                 /*!
                  * @brief Vector of Bins in the Histogram.
@@ -135,6 +130,12 @@ namespace KML
                  * @brief Decay type to decrease histogram counts.
                  */
                 const DecayType m_decay;
+
+            private:
+                /*!
+                 * @brief The value to normalize the counts in the histogram.
+                 */
+                double m_normalizer = 0.0;
         };
     }  // namespace DataStructures
 }  // namespace KML

--- a/tools/cpp/KML/include/data_structures/histograms/StreamingHistogram.h
+++ b/tools/cpp/KML/include/data_structures/histograms/StreamingHistogram.h
@@ -24,20 +24,39 @@ namespace KML
                  * @param  windowSize Number of items to maintain in history.
                  * @param  decay Which decay type to use. Defaults to window.
                  */
-                explicit StreamingHistogram(
-                    const size_t& numBins, const size_t& windowSize,
-                    const DecayType decay = DecayType::WINDOW);
+                explicit StreamingHistogram(const size_t& numBins, const size_t& windowSize,
+                                            const DecayType& decay = DecayType::WINDOW);
+
+                /*!
+                 * @brief Default Copy Constructor.
+                 */
+                StreamingHistogram(const StreamingHistogram& a_rhs) = delete;
+
+                /*!
+                 * @brief Default Assignment Constructor.
+                 */
+                StreamingHistogram& operator=(const StreamingHistogram& a_rhs) = delete;
+
+                /*!
+                 * @brief Move Constructor.
+                 */
+                StreamingHistogram(StreamingHistogram<T>&& other);
+
+                /*!
+                 * @brief Move Assignment.
+                 */
+                StreamingHistogram<T>& operator=(StreamingHistogram<T>&& rhs);
 
                 /*!
                  * @brief Destructor.
                  */
-                virtual ~StreamingHistogram();
+                ~StreamingHistogram();
 
                 /*!
                  * @brief  Takes a single item and updates the deriving class.
                  * @param  item The item used to update deriving class.
                  */
-                virtual void update(const T& item) override;
+                void update(const T& item) override;
 
                 /*!
                  * @copydoc IDataStructure::update()

--- a/tools/cpp/KML/include/data_structures/histograms/StreamingHistogram.tcc
+++ b/tools/cpp/KML/include/data_structures/histograms/StreamingHistogram.tcc
@@ -16,10 +16,8 @@ namespace KML
     namespace DataStructures
     {
         template<typename T>
-        StreamingHistogram<T>::StreamingHistogram(const size_t& numBins,
-                                                  const size_t& windowSize,
-                                                  const DecayType decay)
-            : IStreamingHistogram<T>(numBins, windowSize, decay)
+        StreamingHistogram<T>::StreamingHistogram(const size_t& numBins, const size_t& windowSize,
+            const DecayType& decay) : IStreamingHistogram<T>(numBins, windowSize, decay)
         {
             // Do nothing.
         }
@@ -76,8 +74,7 @@ namespace KML
                 // This will keep the window aligned with indices that have been merged.
                 if (DecayType::WINDOW == this->m_decay)
                 {
-                    for (auto it = this->m_window->begin(); it < this->m_window->end();
-                         it++)
+                    for (auto it = this->m_window->begin(); it < this->m_window->end(); it++)
                     {
                         if (*it == (l_mergedIndex + 1)) *it = l_mergedIndex;
                     }

--- a/tools/cpp/KML/include/metrics/IMetric.h
+++ b/tools/cpp/KML/include/metrics/IMetric.h
@@ -11,12 +11,16 @@ namespace KML
 {
     namespace Metrics
     {
+        /*!
+         * @brief Streaming Metric class.
+         */
         template<typename T = double>
         class IMetric : public IStreaming<T>
         {
             public:
                 /*!
-                 * @brief
+                 * @brief Default Constructor.
+                 * @param windowSize The desired window size streaming metric.
                  */
                 explicit IMetric(const size_t& windowSize);
         };

--- a/tools/cpp/KML/include/metrics/StreamingMAD.h
+++ b/tools/cpp/KML/include/metrics/StreamingMAD.h
@@ -13,11 +13,15 @@ namespace KML
     namespace Metrics
     {
         using KML::Statistics::WindowedFAME;
+
+        /*!
+         * @brief Streaming Median Absolute Deviation (MAD) declarations.
+         */
         class StreamingMAD : public IMetric<double>
         {
             public:
                 /*!
-                 * @brief
+                 * @brief Default Constructor.
                  */
                 StreamingMAD();
 
@@ -42,21 +46,21 @@ namespace KML
                 StreamingMAD& operator=(StreamingMAD&& rhs);
 
                 /*!
-                 * @brief
+                 * @brief Default Destructor.
                  */
                 ~StreamingMAD() override;
 
                 /*!
                  * @copydoc IMetric::update()
                  */
-                using IMetric<double>::update;
                 void update(const double& observation) override;
+                using IMetric<double>::update;
 
                 /*!
                  * @copydoc IMetric::evaluate()
                  */
-                using IMetric<double>::evaluate;
                 double evaluate() const override;
+                using IMetric<double>::evaluate;
 
             private:
                 /*!

--- a/tools/cpp/KML/include/optimizers/IOptimizer.h
+++ b/tools/cpp/KML/include/optimizers/IOptimizer.h
@@ -11,6 +11,9 @@ namespace KML
 {
     namespace Optimizers
     {
+        /*!
+         * @brief Optimizer Interface class declaration.
+         */
         template<typename T = double>
         class IOptimizer
         {
@@ -20,21 +23,6 @@ namespace KML
                  * @details Constructor for every optimizer.
                  */
                 IOptimizer();
-
-                /*!
-                 * @brief Default Copy Constructor.
-                 */
-                IOptimizer(const IOptimizer& a_rhs) = delete;
-
-                /*!
-                 * @brief Default Assignment Constructor.
-                 */
-                IOptimizer& operator=(const IOptimizer& a_rhs) = delete;
-
-                /*!
-                 * @brief Destructor.
-                 */
-                virtual ~IOptimizer();
 
                 /*!
                  * @brief  Takes a single observation and updates the deriving class.

--- a/tools/cpp/KML/include/optimizers/StochasticGradientDescent.h
+++ b/tools/cpp/KML/include/optimizers/StochasticGradientDescent.h
@@ -11,12 +11,15 @@ namespace KML
 {
     namespace Optimizers
     {
+        /*!
+         * @brief Stochastic Gradient Descent class.
+         */
         template<typename T = double>
         class StochasticGradientDescent : public IOptimizer<T>
         {
             public:
                 /*!
-                 * @brief   Default Constructor.
+                 * @brief Default Constructor.
                  */
                 StochasticGradientDescent();
 
@@ -24,7 +27,7 @@ namespace KML
                  * @brief  Takes a single observation and updates the gradient.
                  * @param  observation The observation used to update gradient.
                  */
-                virtual void update(const T& observation) override;
+                void update(const T& observation) override;
         };
     }  // namespace Optimizers
 }  // namespace KML

--- a/tools/cpp/KML/include/statistics/summary/StreamingIQR.h
+++ b/tools/cpp/KML/include/statistics/summary/StreamingIQR.h
@@ -27,7 +27,7 @@ namespace KML
                  *        This window size defaults to a window size of 0, meaning
                  *        the IQR is over the entire data stream.
                  */
-                explicit StreamingIQR(const uint64_t& windowSize = 0);
+                explicit StreamingIQR(const size_t& windowSize = 0);
 
                 /*!
                  * @brief Constructor for setting quantile values.
@@ -38,7 +38,7 @@ namespace KML
                  *        the IQR is over the entire data stream.
                  */
                 explicit StreamingIQR(const double& low = 0.5, const double& high = 0.75,
-                                      const uint64_t& windowSize = 0);
+                                      const size_t& windowSize = 0);
 
                 /*!
                  * Copy Constructor.
@@ -68,14 +68,14 @@ namespace KML
                 /*!
                  * @copydoc IStreamingStatistic::update()
                  */
-                using IStreamingStatistic<double>::update;
                 void update(const double& observation) override;
+                using IStreamingStatistic<double>::update;
 
                 /*!
                  * @copydoc IStreamingStatistic::evaluate()
                  */
-                using IStreamingStatistic<double>::evaluate;
                 double evaluate() const override;
+                using IStreamingStatistic<double>::evaluate;
 
             private:
                 /*!

--- a/tools/cpp/KML/include/statistics/summary/StreamingMean.h
+++ b/tools/cpp/KML/include/statistics/summary/StreamingMean.h
@@ -32,14 +32,14 @@ namespace KML
                 /*!
                  * @copydoc IStreamingStatistic::update()
                  */
-                using IStreamingStatistic<double>::update;
                 void update(const double& observation) override;
+                using IStreamingStatistic<double>::update;
 
                 /*!
                  * @copydoc IStreamingStatistic::evaluate()
                  */
-                using IStreamingStatistic<double>::evaluate;
                 double evaluate() const override;
+                using IStreamingStatistic<double>::evaluate;
 
             private:
                 /*!

--- a/tools/cpp/KML/include/statistics/summary/StreamingP2Quantile.h
+++ b/tools/cpp/KML/include/statistics/summary/StreamingP2Quantile.h
@@ -33,14 +33,14 @@ namespace KML
                 /*!
                  * @copydoc IStreamingStatistic::update()
                  */
-                using IStreamingStatistic<double>::update;
                 void update(const double& observation) override;
+                using IStreamingStatistic<double>::update;
 
                 /*!
                  * @copydoc IStreamingStatistic::update()
                  */
-                using IStreamingStatistic<double>::evaluate;
                 double evaluate() const override;
+                using IStreamingStatistic<double>::evaluate;
 
                 /*!
                  * @brief Clear the current history counter.
@@ -57,14 +57,14 @@ namespace KML
                 /*!
                  * @brief Parabolic quantile interpolation.
                  * @param i Position to interpolate.
-                 * @param desired_pos Sign of desired position (-1, 0, 1);
+                 * @param d_pos Sign of desired position (-1, 0, 1);
                  */
                 double parabolic(int i, double d_pos);
 
                 /*!
                  * @brief Linear quantile interpolation.
-                 * @param pos Position to interpolate.
-                 * @param desired_pos Sign of desired position (-1, 0, 1);
+                 * @param i Position to interpolate.
+                 * @param d_pos Sign of desired position (-1, 0, 1);
                  */
                 double linear(int i, double d_pos);
 

--- a/tools/cpp/KML/include/statistics/summary/StreamingVariance.h
+++ b/tools/cpp/KML/include/statistics/summary/StreamingVariance.h
@@ -58,14 +58,14 @@ namespace KML
                 /*!
                  * @copydoc IStreamingStatistic::update()
                  */
-                using IStreamingStatistic<double>::update;
                 void update(const double& observation) override;
+                using IStreamingStatistic<double>::update;
 
                 /*!
                  * @copydoc IStreamingStatistic::evaluate()
                  */
-                using IStreamingStatistic<double>::evaluate;
                 double evaluate() const override;
+                using IStreamingStatistic<double>::evaluate;
 
             private:
                 /*!

--- a/tools/cpp/KML/include/statistics/summary/WindowedFAME.h
+++ b/tools/cpp/KML/include/statistics/summary/WindowedFAME.h
@@ -13,6 +13,9 @@ namespace KML
 {
     namespace Statistics
     {
+        /*!
+         * @brief Fast Algorithm for Median Estimation (FAME) declaration.
+         */
         class WindowedFAME : public IStreamingStatistic<double>
         {
             public:
@@ -27,14 +30,14 @@ namespace KML
                 /*!
                  * @copydoc IStreamingStatistic::update()
                  */
-                using IStreamingStatistic<double>::update;
                 void update(const double& observation) override;
+                using IStreamingStatistic<double>::update;
 
                 /*!
                  * @copydoc IStreamingStatistic::evaluate()
                  */
-                using IStreamingStatistic<double>::evaluate;
                 double evaluate() const override;
+                using IStreamingStatistic<double>::evaluate;
 
             private:
                 /*!

--- a/tools/cpp/KML/include/statistics/summary/WindowedP2Quantile.h
+++ b/tools/cpp/KML/include/statistics/summary/WindowedP2Quantile.h
@@ -14,12 +14,15 @@ namespace KML
 {
     namespace Statistics
     {
+        /*!
+         * @brief Windowed implemented of the StreamingP2Quantile class.
+         */
         class WindowedP2Quantile : IStreamingStatistic<double>
         {
             public:
                 /*!
                  * @brief Default Constructor.
-                 * @param Desired quantile to calculate.
+                 * @param quantile Desired quantile to calculate.
                  * @param windowSize The window size to calculate the streaming quantile.
                  *        This window size defaults to a window size of 0, meaning
                  *        the quantile is over the entire data stream.
@@ -55,14 +58,14 @@ namespace KML
                 /*!
                  * @copydoc IStreamingStatistic::update()
                  */
-                using IStreamingStatistic<double>::update;
                 void update(const double& observation) override;
+                using IStreamingStatistic<double>::update;
 
                 /*!
                  * @copydoc IStreamingStatistic::evaluate()
                  */
-                using IStreamingStatistic<double>::evaluate;
                 double evaluate() const override;
+                using IStreamingStatistic<double>::evaluate;
 
             private:
                 /*!

--- a/tools/cpp/KML/include/statistics/transformers/AdaptiveNormalizer.h
+++ b/tools/cpp/KML/include/statistics/transformers/AdaptiveNormalizer.h
@@ -2,7 +2,7 @@
  * @file  AdaptiveNormalizer.h
  * @brief Provides declarations for adaptive normalization.
  *
- * @reference https://arxiv.org/ftp/arxiv/papers/1910/1910.07696.pdf
+ * Reference: https://arxiv.org/ftp/arxiv/papers/1910/1910.07696.pdf
  */
 #ifndef __ADAPTIVE_TRANSFORMER_H__
 #define __ADAPTIVE_TRANSFORMER_H__

--- a/tools/cpp/KML/src/statistics/summary/WindowedP2Quantile.cc
+++ b/tools/cpp/KML/src/statistics/summary/WindowedP2Quantile.cc
@@ -1,8 +1,6 @@
 /*!
  * @file  WindowedP2Quantile.cc
  * @brief Implemenation of the windowed quantile estimation.
- *
- * @reference https://aakinshin.net/tags/research-p2qe/
  */
 #include "WindowedP2Quantile.h"
 

--- a/tools/cython/KML/data_structures/LinkedList.pyx
+++ b/tools/cython/KML/data_structures/LinkedList.pyx
@@ -30,7 +30,7 @@ cdef class PyLinkedList:
     Args:
         window_size (int, optional): Desired window size for LinkedList. Defaults to None.
 
-    Attributes:
+    Parameters:
         c_LL (LinkedList[float]*): Pointer to the C++ LinkedList implementation.
         window_size (int, optional): Desired window size for LinkedList.
     """

--- a/tools/cython/KML/data_structures/RingBuffer.pyx
+++ b/tools/cython/KML/data_structures/RingBuffer.pyx
@@ -30,7 +30,7 @@ cdef class PyRingBuffer:
     Args:
         window_size (int, optional): Desired window size for ring buffer. Defaults to None.
 
-    Attributes:
+    Parameters:
         c_RB (RingBuffer[float]*): Pointer to the C++ RingBuffer implementation.
         window_size (int, optional): Desired window size for ring buffer. Defaults to None.
     """

--- a/tools/cython/KML/data_structures/histograms/StreamingHistogram.pyx
+++ b/tools/cython/KML/data_structures/histograms/StreamingHistogram.pyx
@@ -36,7 +36,7 @@ cdef class PyStreamingHistogram:
         window_size (int, optional): Desired window size for StreamingHistogram. Defaults to 100.
         decay_type (DecayType, optional): How to decay the counts when outside of scope.
 
-    Attributes:
+    Parameters:
         c_SH (StreamingHistogram[double]*): Pointer to the C++ StreamingHistogram implementation.
         num_bins (int): Number of bins the histogram should have.
         window_size (int, optional): Desired window size for StreamingHistogram. Defaults to 100.

--- a/tools/cython/KML/metrics/StreamingMAD.pyx
+++ b/tools/cython/KML/metrics/StreamingMAD.pyx
@@ -25,7 +25,7 @@ cdef class PyStreamingMAD:
     The mad value is calculated using the WindowedFame code, and inherently adjusts
     for data drift.
 
-    Attributes:
+    Parameters:
         c_MAD (StreamingMAD*): Pointer to the C++ StreamingMAD implementation.
     """
     cdef StreamingMAD *c_MAD

--- a/tools/cython/KML/statistics/summary/StreamingIQR.pyx
+++ b/tools/cython/KML/statistics/summary/StreamingIQR.pyx
@@ -30,7 +30,7 @@ cdef class PyStreamingIQR:
         high (float, optional): High range (defaults to 75% quartile). Defaults to None.
         window_size (int, optional): Desired window size. Defaults to None.
 
-    Attributes:
+    Parameters:
         c_IQR (StreamingIqR*): Pointer to the C++ StreamingIQR implementation.
         low (float, optional): Low range (defaults to 25% quartile). Defaults to None.
         high (float, optional): High range (defaults to 75% quartile). Defaults to None.

--- a/tools/cython/KML/statistics/summary/StreamingMean.pyx
+++ b/tools/cython/KML/statistics/summary/StreamingMean.pyx
@@ -28,7 +28,7 @@ cdef class PyStreamingMean:
     Args:
         window_size (int, optional): Desired window size. Defaults to None.
 
-    Attributes:
+    Parameters:
         c_SM (StreamingMean*) : Pointer to the C++ StreamingMean implementation.
         window_size (int, optional): Desired window size. Defaults to None.
     """

--- a/tools/cython/KML/statistics/summary/StreamingP2Quantile.pyx
+++ b/tools/cython/KML/statistics/summary/StreamingP2Quantile.pyx
@@ -28,7 +28,7 @@ cdef class PyStreamingP2Quantile:
     Args:
         quantile (float): Quantile to calculate. Defaults to 0.5.
 
-    Attributes:
+    Parameters:
         quantile (float): Quantile to calculate. Defaults to 0.5.
     """
     cdef StreamingP2Quantile* c_P2

--- a/tools/cython/KML/statistics/summary/StreamingVariance.pyx
+++ b/tools/cython/KML/statistics/summary/StreamingVariance.pyx
@@ -28,7 +28,7 @@ cdef class PyStreamingVariance:
     Args:
         window_size (int, optional): Desired window size. Defaults to None.
 
-    Attributes:
+    Parameters:
         c_SM (StreamingVariance*) : Pointer to the C++ StreamingVariance implementation.
         window_size (int, optional): Desired window size.
     """

--- a/tools/cython/KML/statistics/summary/WindowedFAME.pyx
+++ b/tools/cython/KML/statistics/summary/WindowedFAME.pyx
@@ -30,7 +30,7 @@ cdef class PyWindowedFAME:
         epsilon (float, optional): epsilon The exponential growth factor. This gives the
                          median calculation a "windowing flavor". Defaults to 0.0.
 
-    Attributes:
+    Parameters:
         c_FM (WindowedFAME*) : Pointer to the C++ WindowedFAME implementation.
         step_size (int, optional): The step size to take when calculating median. Defaults to 0.1.
         epsilon (float, optional): epsilon The exponential growth factor. This gives the

--- a/tools/cython/KML/statistics/summary/WindowedP2Quantile.pyx
+++ b/tools/cython/KML/statistics/summary/WindowedP2Quantile.pyx
@@ -25,7 +25,7 @@ cdef class PyWindowedP2Quantile:
         quantile (float): Quantile to calculate.
         window_size (int, optional): Desired window size. Defaults to None.
 
-    Attributes:
+    Parameters:
         c_WP2 (WindowedP2Quantile*) : Pointer to the C++ WindowedP2Quantile implementation.
         quantile (float): Quantile to calculate.
         window_size (int, optional): Desired window size. Defaults to None.


### PR DESCRIPTION
Fixed the failing documentation after adding in static checking. Fixed the exhale documentation warnings due to incorrectly documented headers.